### PR TITLE
Add a command integration for 'jetpack rsync'

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       {
         "command": "jetpack.helloWorld",
         "title": "Hello World"
+      },
+      {
+        "command": "jetpack.rsync",
+        "title": "Jetpack: Rsync"
       }
     ]
   },

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -1,22 +1,43 @@
+import {execSync} from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {findJetpackRoot} from '../util';
 
-const getPlugins = () => {
+const getPlugins = (rootPath: string) =>
+    fs.readdirSync(path.join(rootPath, 'projects', 'plugins'), {withFileTypes: true})
+        .filter(result => result.isDirectory())
+        .map(result => result.name);
+
+export const rsyncCommand = async () => {
     const jetpackRoot = findJetpackRoot();
 
     if (!jetpackRoot) {
-        return [];
+        return;
     }
 
-    return fs.readdirSync(path.join(jetpackRoot, 'projects', 'plugins'), {withFileTypes: true})
-        .filter(result => result.isDirectory())
-        .map(result => result.name);
-};
-
-export const rsyncCommand = async () => {
-    const plugin = await vscode.window.showQuickPick(getPlugins(), {
+    const plugin = await vscode.window.showQuickPick(getPlugins(jetpackRoot), {
         placeHolder: "Which plugin would you like to sync?",
     });
+
+    const wpPath = await vscode.window.showInputBox({
+        prompt: 'Enter the remote path to upload the plugin contents to.',
+        placeHolder: 'user@server:public_html/wp-content/plugins/jetpack',
+    });
+
+    const confirmation = await vscode.window.showWarningMessage(
+        `You're about to upload the contents of plugins/${plugin} to ${wpPath}. Do you want to proceed?`,
+        'Yes',
+        'No'
+    );
+
+    if (confirmation !== 'Yes') {
+        return;
+    }
+
+    try {
+        execSync(`pnpm jetpack rsync ${plugin} ${wpPath}`, {cwd: jetpackRoot});
+    } catch (error) {
+        console.log(error);
+    }
 };

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {findJetpackRoot} from '../util';
+
+const getPlugins = () => {
+    const jetpackRoot = findJetpackRoot();
+
+    if (!jetpackRoot) {
+        return [];
+    }
+
+    return fs.readdirSync(path.join(jetpackRoot, 'projects', 'plugins'), {withFileTypes: true})
+        .filter(result => result.isDirectory())
+        .map(result => result.name);
+};
+
+export const rsyncCommand = async () => {
+    const plugin = await vscode.window.showQuickPick(getPlugins(), {
+        placeHolder: "Which plugin would you like to sync?",
+    });
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,13 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import {findJetpackRoot} from './util';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+	const jetpackRoot = findJetpackRoot();
+
+	if (!jetpackRoot) {
+		vscode.window.showErrorMessage("Jetpack monorepo not found within the current workspace.");
+		return;
+	}
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+
+import {rsyncCommand} from './commands/rsync';
 import {findJetpackRoot} from './util';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -22,7 +24,10 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage('Hello World from Jetpack!');
 	});
 
+	let rsync = vscode.commands.registerCommand('jetpack.rsync', rsyncCommand);
+
 	context.subscriptions.push(disposable);
+	context.subscriptions.push(rsync);
 }
 
 // This method is called when your extension is deactivated

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,41 @@
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const isJetpackRoot = (folderPath: string) => {
+    if (!folderPath) {
+        return false;
+    }
+
+    try {
+        const packageJson = JSON.parse(fs.readFileSync(path.join(folderPath, 'package.json'), 'utf8'));
+
+        return packageJson && packageJson.name === '@automattic/Jetpack_Monorepo';
+    } catch (error) {
+        console.log(error);
+        return false;
+    }
+};
+
+const findGitRoot = (uri: vscode.Uri) =>
+    execSync('git rev-parse --show-toplevel', {cwd: uri.fsPath}).toString().trim();
+
+export const findJetpackRoot = () => {
+    const gitExtension = vscode.extensions.getExtension('vscode.git')?.exports;
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+
+    if (!gitExtension || !workspaceFolders) {
+        return null;
+    }
+
+    for (const folder of workspaceFolders) {
+        const gitRootPath = findGitRoot(folder.uri);
+
+        if (isJetpackRoot(gitRootPath)) {
+            return gitRootPath;
+        }
+    }
+
+    return null;
+};


### PR DESCRIPTION
This is an initial proof of concept for how we can integrate our more 'advanced' CLI commands with VS Code using this extension. There are some quirks to it but I believe this is sufficient to get an initial feel and start more experiments with either this or other commands.

I think it does everything the CLI version does except remembering your remotes, which can be added, although I'm trying to think if we can maybe even make that process easier for ourselves by providing some pre-provisioned paths inside a setting or something.

At the end, there's a confirmation dialog, which I think is handy as rsync just overrides whatever you point it at. And with the current flow it's quite easy to make a typo. I'm not entirely satisfied with how that's presented so that's something to improve upon maybe.

Also, I noticed there's currently no way to cancel the flow. Pressing `Esc` simply proceeds to the next step and that confirmation dialog is the only place where you can abort the command. This is also something to improve.

Pics or didn't happen:

![Screenshot 2023-10-13 at 21 50 37](https://github.com/Automattic/jetpack-vscode/assets/8056203/f3e4e02b-feec-4413-a9df-3c4b99f96008)
![Screenshot 2023-10-13 at 21 50 55](https://github.com/Automattic/jetpack-vscode/assets/8056203/dfa7b681-6860-4a1e-a40e-43dde8c8dd09)
![Screenshot 2023-10-13 at 21 51 09](https://github.com/Automattic/jetpack-vscode/assets/8056203/41eb9c48-308f-482f-8593-5ae8a7b4e094)
![Screenshot 2023-10-13 at 21 51 22](https://github.com/Automattic/jetpack-vscode/assets/8056203/50adde48-2638-40de-9631-f1d075ec3a49)

# Testing

- You need to open this project in VSCode and hit `F5` to build a developer version.
- Once the developer version is launched, try running the `Jetpack Rsync` command without having anything in your workspace just yet.
- The command should fail because it cannot find a Jetpack Monorepo instance.
- Add the monorepo to your workspace.
- The command should now work as expected.