### PR TITLE
Implement support for 'jetpack watch'

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
       {
         "command": "jetpack.rsync",
         "title": "Jetpack: Rsync"
+      },
+      {
+        "command": "jetpack.watchProject",
+        "title": "Jetpack: Watch Project"
+      },
+      {
+        "command": "jetpack.watchProject.stop",
+        "title": "Jetpack: Stop Watching Project"
       }
     ]
   },

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -58,11 +58,20 @@ export const stopWatchingProjectCommand = async () => {
     }
 
     const taskName = await vscode.window.showQuickPick(
-        activeWatchers.map(({name}) => ({label: name})),
+        [
+            {label: 'Stop all tasks'},
+            ...activeWatchers.map(({name}) => ({label: name}))
+        ],
         {placeHolder: 'Which task do you want to stop?'}
     );
 
     if (!taskName) {
+        return;
+    }
+
+    if (taskName.label === 'Stop all tasks') {
+        activeWatchers.forEach(({name}) => removeTask(name));
+        updateStatusBar();
         return;
     }
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,0 +1,81 @@
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {findJetpackRoot} from '../util';
+import { addTask, getTasksByType, removeTask, TaskType } from '../tasks';
+import { updateStatusBar } from '../widgets/status-bar';
+
+const PROJECT_TYPES = [ 'github-actions', 'js-packages', 'packages', 'plugins' ];
+
+const getProjectsByType = (type: string, rootPath: string) =>
+    fs.readdirSync(path.join(rootPath, 'projects', type), {withFileTypes: true})
+        .filter(result => result.isDirectory())
+        .map(result => ({ label: result.name}));
+
+
+export const watchProjectCommand = async () => {
+    const jetpackRoot = findJetpackRoot();
+
+    if (!jetpackRoot) {
+        return;
+    }
+
+    const projectType = await vscode.window.showQuickPick(PROJECT_TYPES.map((label) => ({label})), {
+        placeHolder: 'What project type are you working on?',
+    });
+
+    if (!projectType) {
+        return;
+    }
+
+    const project = await vscode.window.showQuickPick(getProjectsByType(projectType.label, jetpackRoot), {
+        placeHolder: 'Which project?',
+    });
+
+    if (!project) {
+        return;
+    }
+
+    const terminal = vscode.window.createTerminal({ cwd: jetpackRoot, name: `jetpack watch ${projectType.label}/${project.label}` });
+    terminal.sendText(`pnpm jetpack watch ${projectType.label}/${project.label}`);
+
+    const task = {
+        name: `${projectType.label}/${project.label}`,
+        type: TaskType.WatchTask,
+        terminal,
+    };
+
+    addTask(task);
+    updateStatusBar();
+};
+
+export const stopWatchingProjectCommand = async () => {
+    const activeWatchers = getTasksByType(TaskType.WatchTask);
+
+    if (!activeWatchers) {
+        return;
+    }
+
+    const taskName = await vscode.window.showQuickPick(
+        activeWatchers.map(({name}) => ({label: name})),
+        {placeHolder: 'Which task do you want to stop?'}
+    );
+
+    if (!taskName) {
+        return;
+    }
+
+    const index = activeWatchers.findIndex((task) => task.name === taskName.label);
+
+    if (index < 0) {
+        return;
+    }
+
+    const task = activeWatchers[index];
+    if (task.terminal) {
+        task.terminal.dispose();
+    }
+    removeTask(taskName.label);
+    updateStatusBar();
+};

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {findJetpackRoot} from '../util';
 import { addTask, getTasksByType, removeTask, TaskType } from '../tasks';
+import {callTrackEvent} from '../tracks';
 import { updateStatusBar } from '../widgets/status-bar';
 
 const PROJECT_TYPES = [ 'github-actions', 'js-packages', 'packages', 'plugins' ];
@@ -48,6 +49,8 @@ export const watchProjectCommand = async () => {
 
     addTask(task);
     updateStatusBar();
+
+    callTrackEvent('jetpackvsc_command_exec');
 };
 
 export const stopWatchingProjectCommand = async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,11 +27,13 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	let rsync = vscode.commands.registerCommand('jetpack.rsync', rsyncCommand);
-	let watchprojet = vscode.commands.registerCommand('jetpack.watchProject', watchProjectCommand);
+	let watchproject = vscode.commands.registerCommand('jetpack.watchProject', watchProjectCommand);
 	let stopWatchingProject = vscode.commands.registerCommand('jetpack.watchProject.stop', stopWatchingProjectCommand);
 
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(rsync);
+	context.subscriptions.push(watchproject);
+	context.subscriptions.push(stopWatchingProject);
 
 	activateStatusBar(context);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 
 import {rsyncCommand} from './commands/rsync';
+import { watchProjectCommand, stopWatchingProjectCommand } from './commands/watch';
+import { activateStatusBar } from './widgets/status-bar';
 import {findJetpackRoot} from './util';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -25,9 +27,13 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	let rsync = vscode.commands.registerCommand('jetpack.rsync', rsyncCommand);
+	let watchprojet = vscode.commands.registerCommand('jetpack.watchProject', watchProjectCommand);
+	let stopWatchingProject = vscode.commands.registerCommand('jetpack.watchProject.stop', stopWatchingProjectCommand);
 
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(rsync);
+
+	activateStatusBar(context);
 }
 
 // This method is called when your extension is deactivated

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+
+export enum TaskType {
+    WatchTask,
+};
+
+export interface Task {
+    name: string;
+    type: TaskType;
+    terminal?: vscode.Terminal;
+};
+
+const activeTasks: Task[] = [];
+
+export const addTask = (task: Task) =>
+    activeTasks.push(task);
+
+export const removeTask = (name: string) => {
+    const index = activeTasks.findIndex((task) => task.name === name);
+
+    if (index < 0) {
+        return;
+    }
+
+    activeTasks.splice(index, 1);
+};
+
+export const getTasks = () => activeTasks;
+
+export const getTasksByType = (type: TaskType) =>
+    activeTasks.filter((task) => task.type === type);

--- a/src/widgets/status-bar.ts
+++ b/src/widgets/status-bar.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+import { addTask, getTasks, getTasksByType, removeTask, TaskType, Task } from '../tasks';
+
+export const updateStatusBar = () => {
+    const watchers = getTasksByType(TaskType.WatchTask);
+
+    vscode.window.setStatusBarMessage(`Jetpack ${watchers.length}`);
+};
+
+export const activateStatusBar = ({ subscriptions }: vscode.ExtensionContext): void => {
+    subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {
+        const task = getTasks().find(({terminal}: Task) => terminal === closedTerminal);
+
+        if (!task) {
+            return;
+        }
+
+        removeTask(task.name);
+        updateStatusBar();
+    }));
+};

--- a/src/widgets/status-bar.ts
+++ b/src/widgets/status-bar.ts
@@ -1,13 +1,28 @@
 import * as vscode from 'vscode';
 import { addTask, getTasks, getTasksByType, removeTask, TaskType, Task } from '../tasks';
 
+let statusBar: vscode.StatusBarItem;
+
 export const updateStatusBar = () => {
     const watchers = getTasksByType(TaskType.WatchTask);
 
-    vscode.window.setStatusBarMessage(`Jetpack ${watchers.length}`);
+    if (watchers.length === 0) {
+        statusBar.hide();
+        return;
+    }
+
+    statusBar.command = 'jetpack.watchProject.stop';
+    statusBar.name = 'Jetpack status';
+    statusBar.text = `$(heart-filled) ${watchers.length}`;
+    statusBar.tooltip = 'Currently watching:\n' + watchers.map(({name}) => `- ${name}`).join('\n');
+
+    statusBar.show();
 };
 
 export const activateStatusBar = ({ subscriptions }: vscode.ExtensionContext): void => {
+    statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    subscriptions.push(statusBar);
+
     subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {
         const task = getTasks().find(({terminal}: Task) => terminal === closedTerminal);
 


### PR DESCRIPTION
Adds commands for watching and unwatching Jetpack projects as well as a status bar item to keep track of active watchers.
Potential to do's:

- [x] Add another entry to stop watching all 'active' projects.
- [ ] ~Parse terminal output for errors.~
- [x] Add tracks.

# Testing

- Run `npm run compile` and fire up the VSC development build.
- There should be two new commands `Jetpack: Watch Project` and `Jetpack: Stop Watching Projects`.
- The latter command shouldn't do anything unless you're already watching at least one project.
- Trigger `Jetpack: Watch Project`.
- It should walk you through the menus to select a project to watch.
- A 'heart' indicator should appear in the bottom status bar with the number of currently watched projects.
- Hovering over the indicator for a bit will list all actively watched projects.
- Clicking on the indicator will fire 'Jetpack: Stop Watching Projects'.
- You should be able to stop watching projects individually or all of them at once using the appropriate option.
- `Jetpack: Watch Project` should also be registered in the live view in tracks.