### PR TITLE
RSync: Support Jurassic Ninja and Enter Site Path More Gracefully

### DIFF
--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -40,9 +40,24 @@ export const rsyncCommand = async () => {
         return;
     }
 
-    try {
-        execSync(`pnpm jetpack rsync ${plugin} ${wpPath}`, {cwd: jetpackRoot});
-    } catch (error) {
-        console.log(error);
-    }
-};
+	// If wpPath includes "jurassic.ninja" we need to open a terminal so the password can be entered.
+	// Otherwise, we can just run the command in the background.
+	if (wpPath.includes('jurassic.ninja')) {
+		const terminal = vscode.window.createTerminal({
+			name: 'Jetpack Rsync',
+			cwd: jetpackRoot,
+		});
+		terminal.show();
+		try {
+			terminal.sendText(`pnpm jetpack rsync ${plugin} ${wpPath}`);
+		} catch (error) {
+			console.log(error);
+		}
+	} else {
+		try {
+			execSync(`pnpm jetpack rsync ${plugin} ${wpPath}`, {cwd: jetpackRoot});
+		} catch (error) {
+			console.log(error);
+		}
+	}
+}

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -57,6 +57,7 @@ export const rsyncCommand = async () => {
 	try {
 		terminal.sendText(`pnpm jetpack rsync ${plugin} ${wpPath}`);
 	} catch (error) {
+		terminal.show();
 		console.log(error);
 	}
 }

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -23,7 +23,12 @@ export const rsyncCommand = async () => {
     const wpPath = await vscode.window.showInputBox({
         prompt: 'Enter the remote path to upload the plugin contents to.',
         placeHolder: 'user@server:public_html/wp-content/plugins/jetpack',
+		ignoreFocusOut: true,
     });
+
+	if (!plugin || !wpPath) {
+		return;
+	}
 
     const confirmation = await vscode.window.showWarningMessage(
         `You're about to upload the contents of plugins/${plugin} to ${wpPath}. Do you want to proceed?`,

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -44,24 +44,19 @@ export const rsyncCommand = async () => {
         return;
     }
 
-	// If wpPath includes "jurassic.ninja" we need to open a terminal so the password can be entered.
-	// Otherwise, we can just run the command in the background.
+	const terminal = vscode.window.createTerminal({
+		name: 'Jetpack Rsync',
+		cwd: jetpackRoot,
+	});
+
+	// Show the terminal if connecting to a Jurassic.ninja site so that the user can enter their password.
 	if (wpPath.includes('jurassic.ninja')) {
-		const terminal = vscode.window.createTerminal({
-			name: 'Jetpack Rsync',
-			cwd: jetpackRoot,
-		});
 		terminal.show();
-		try {
-			terminal.sendText(`pnpm jetpack rsync ${plugin} ${wpPath}`);
-		} catch (error) {
-			console.log(error);
-		}
-	} else {
-		try {
-			execSync(`pnpm jetpack rsync ${plugin} ${wpPath}`, {cwd: jetpackRoot});
-		} catch (error) {
-			console.log(error);
-		}
+	}
+
+	try {
+		terminal.sendText(`pnpm jetpack rsync ${plugin} ${wpPath}`);
+	} catch (error) {
+		console.log(error);
 	}
 }

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -20,13 +20,17 @@ export const rsyncCommand = async () => {
         placeHolder: "Which plugin would you like to sync?",
     });
 
+	if (!plugin) {
+		return;
+	}
+
     const wpPath = await vscode.window.showInputBox({
         prompt: 'Enter the remote path to upload the plugin contents to.',
         placeHolder: 'user@server:public_html/wp-content/plugins/jetpack',
 		ignoreFocusOut: true,
     });
 
-	if (!plugin || !wpPath) {
+	if (!wpPath) {
 		return;
 	}
 


### PR DESCRIPTION
This PR does the following:

- Allows the command prompt to lose focus without submitting the remote path.
- Allows user to use ESC to exit the prompt without continuing the rsync.
- Supports Jurassic Ninja Sites by opening a terminal when connecting to allow you to enter a password.

### To Test

- Pull down this branch and open it in VS Code
- Run `npm run compile` to build the extension.
- Open the src/extension.ts file in VS Code and hit F5 to launch a new workspace with the extension active.
- In the new workspace, open the jetpack monorepo.
- Open the command palette, ctrl + shift + P and search for the Jetapck RSync command.
- You should be able to hit escape to exit the command.
- When it prompts you to enter a remote path, you should be able to click away from the window, do what you need to do, and come back to enter the path.
- If you're rsyncing to a JN site, it should open a terminal to prompt you to enter the site's password before completing the command.
