### PR TITLE
Don't show rsync confirmation notification for existing sites

### DIFF
--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -70,7 +70,7 @@ export const rsyncCommand = async () => {
 		return;
 	}
 
-	if (existingSite !== newSiteOption) {
+	if (existingSite === newSiteOption) {
 		const confirmation = await vscode.window.showWarningMessage(
 			`You're about to upload the contents of plugins/${plugin} to ${wpPath}. Do you want to proceed?`,
 			'Yes',

--- a/src/commands/rsync.ts
+++ b/src/commands/rsync.ts
@@ -70,15 +70,17 @@ export const rsyncCommand = async () => {
 		return;
 	}
 
-    const confirmation = await vscode.window.showWarningMessage(
-        `You're about to upload the contents of plugins/${plugin} to ${wpPath}. Do you want to proceed?`,
-        'Yes',
-        'No'
-    );
+	if (existingSite !== newSiteOption) {
+		const confirmation = await vscode.window.showWarningMessage(
+			`You're about to upload the contents of plugins/${plugin} to ${wpPath}. Do you want to proceed?`,
+			'Yes',
+			'No'
+		);
 
-    if (confirmation !== 'Yes') {
-        return;
-    }
+		if (confirmation !== 'Yes') {
+			return;
+		}
+	}
 
 	const terminal = vscode.window.createTerminal({
 		name: 'Jetpack Rsync',


### PR DESCRIPTION
Let's maybe not show the confirmation notification for existing sites. The placement is a bit odd and I feel like it doesn't quite fit into the flow, yet I think it's important when you're typing out a path manually. But for existing paths we should be able to skip it.

# Testing

- Run `npm run compile` and fire up a dev build for VSCode.
- Run `Jetpack: Rsync`.
- The confirmation warning should only appear when you want to add a new site/remote.